### PR TITLE
Fix issue 16: Don't trigger delete requests when pressing ENTER elsewhere on the form

### DIFF
--- a/treestatus/static/deletebuttons.js
+++ b/treestatus/static/deletebuttons.js
@@ -1,0 +1,38 @@
+function deleteUser(user) {
+  var f = document.getElementById('deleteForm');
+  var input = document.createElement('input');  
+  input.setAttribute('type', 'submit');
+  input.setAttribute('value', 'Delete');
+  input.setAttribute('name', user);
+  input.setAttribute('form', 'deleteForm');
+  f.appendChild(input);
+  input.click();
+}
+
+
+function onDeleteButtonClick(e) {
+  var id = e.target.id;
+  if (id.indexOf('delete:') != 0)
+    return;
+
+  e.preventDefault();
+  var elems = document.getElementsByTagName('button');
+  for (var i = 0; i < elems.length; i++) {
+    elems[i].removeEventListener('click', onDeleteButtonClick);
+  }
+
+  deleteUser(id);
+}
+
+
+function onLoad() {
+  document.removeEventListener('DOMContentLoaded', onLoad);
+
+  var elems = document.getElementsByTagName("button");
+  for (var i = 0; i < elems.length; i++) {
+    elems[i].addEventListener('click', onDeleteButtonClick);
+  }
+}
+
+
+document.addEventListener('DOMContentLoaded', onLoad, 'false');

--- a/treestatus/static/style.css
+++ b/treestatus/static/style.css
@@ -74,6 +74,10 @@ a:hover.loginout, a:active.loginout {
     text-decoration: none;
 }
 
+.none {
+  display: none;
+}
+
 .error {
     color: red;
 }

--- a/treestatus/templates/users.html
+++ b/treestatus/templates/users.html
@@ -3,6 +3,7 @@
 <head>
     <title>Tree Status</title>
     <link rel="stylesheet" type="text/css" href="/static/style.css" />
+    <script type="application/javascript" src="/static/deletebuttons.js"></script>
 </head>
 <body>
     <div id="container">
@@ -41,7 +42,7 @@
                                 <td class="tableSheriff"><input type="checkbox" name="sheriff" value="{{u.id}}" {{'checked=1' if u.is_sheriff else ''}}/></td>
                                 <td class="tableAdmin"><input type="checkbox" name="admin" value="{{u.id}}" {{'checked=1' if u.is_admin else ''}}/></td>
                                 <td class="tableDelete">
-                                    <input type="submit" name="delete:{{u.id}}" value="Delete" />
+                                    <button type="button" id="delete:{{u.id}}">Delete</button>
                                 <td/>
                             </tr>
                             {% endfor -%}
@@ -50,6 +51,9 @@
                     <div id="modify">
                         <span class="atRight"><input type="submit" value="Submit"/></span>
                     </div>
+                </form>
+                <form method="post" action="">
+                    <input type="hidden" name="token" value="{{token}}">
                     <div id="add">
                         <label for="newuser">Add user:
                           <input type="text" name="newuser" />
@@ -58,6 +62,10 @@
                     </div>
                 </form>
             </div>
+
+            <form id="deleteForm" class="none" method="post" action="">
+                <input type="hidden" name="token" value="{{token}}">
+            </form>
         </div>
 
         <div id="footer">


### PR DESCRIPTION
This change also decouples "Add User" from the rest of the form - I don't think it's obvious that hitting enter there will also submit any modifications you have made to existing users.
