### PR TITLE
Automatically transform "bug XXXXXX" into a b.m.o link in JSON output

### DIFF
--- a/treestatus/app.py
+++ b/treestatus/app.py
@@ -6,6 +6,7 @@ site.addsitedir(os.path.join(my_dir, "vendor/lib/python"))
 from datetime import datetime
 import urllib
 from binascii import b2a_base64
+import re
 
 from simplejson import dumps, loads
 import memcache
@@ -288,7 +289,17 @@ def is_json():
         return True
     return False
 
+def link_match(match):
+    return '<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=%s">%s</a>' % (match.group(1), match.group(0))
+
+def link_bugs(s):
+    return re.sub('bug\s+(\d{6,7})(?!\s*</a>)', link_match, s, flags=re.I)
+
 def wrap_json_headers(data):
+    if 'reason' in data:
+        data['reason'] = link_bugs(data['reason'])
+    if 'message_of_the_day' in data:
+        data['message_of_the_day'] = link_bugs(data['message_of_the_day'])
     response = jsonify(data)
     response.headers['Access-Control-Allow-Origin'] = '*'
     response.headers['Cache-Control'] = 'no-cache'


### PR DESCRIPTION
I'm sure I remember seeing edmorley wish for this, though I don't remember where!

"bug XXXXXX" will only be transformed if it does not appear to be already part of a link: I'm using a fairly simple heuristic of looking for a closing </a> tag following the bug number, but I think this should be sufficient for our purposes.

This only affects the JSON output. If "bug XXXXXX" was expanded in all cases - e.g. by sticking the relevant code into Status.get_tree(s) - then if we pre-fill the fields per issue 22, on submission the sheriff may find the field unexpectedly truncated as the form submission would then include the full link text (76 characters). The only alternative would be to strip out any Bugzilla links from the reason and motd fields prior to being stored in the DB - that seemed needlessly invasive.
