### PR TITLE
Bug 823627 - Increase the size of the 'reason' textbox to display more of the reason without scrolling

### DIFF
--- a/treestatus/static/style.css
+++ b/treestatus/static/style.css
@@ -101,6 +101,7 @@ p.error {
 
 .tableReason {
     min-width: 400px;
+    max-width: 700px
 }
 
 .tableTree {
@@ -109,6 +110,7 @@ p.error {
 
 .history .tableReason {
     min-width: 200px;
+    max-width: 600px;
 }
 
 .history td {
@@ -222,6 +224,10 @@ h2#previous {
     width: 100%;
     text-align: center;
     height: 60px;
+}
+
+label[for=reason] {
+    padding-top: 5px;
 }
 
 .tableDelete {

--- a/treestatus/templates/index.html
+++ b/treestatus/templates/index.html
@@ -100,8 +100,9 @@ window.onload = validateForm;
                       </select>
                   </label><br/>
 
-                  <label for="reason">Reason:</label>
-                  <input type="text" name="reason" id="reason" size="30" /><br/><br/>
+                  <label for="reason">Reason:
+                      <input type="text" name="reason" id="reason" size="70" />
+                  </label><br/><br/>
 
                   <input type="checkbox" name="tags" value="checkin-compilation" id="checkin-compilation" onclick="validateForm()" />
                   <label for="checkin-compilation">Check-in compilation failure</label><br/>

--- a/treestatus/templates/tree.html
+++ b/treestatus/templates/tree.html
@@ -60,10 +60,11 @@ window.onload = validateForm;
                             <option value="open">Open</option>
                             <option value="approval required">Approval Required</option>
                         </select>
-                    </label>
+                    </label><br/>
 
-                    <label for="reason">Reason:</label>
-                    <input type="text" name="reason" size="30" value="{{tree.reason}}"/><br/>
+                    <label for="reason">Reason:
+                        <input type="text" name="reason" id="reason" value="{{tree.reason}}" size="70" />
+                    </label><br/><br/>
 
                     <input type="checkbox" name="tags" value="checkin-compilation" id="checkin-compilation" onclick="validateForm()" />
                     <label for="checkin-compilation">Check-in compilation failure</label><br/>


### PR DESCRIPTION
This increases the width of the reason input fields to 70 characters (same as MOTD). 

It also adds a bit of padding to the field so it's not pushed right up against the New State line.

It also puts a max-width onto the reason column in the history tables, though it looks a bit funny if the reason is a long string without any breaks (it overflows into the tags column).