### PR TITLE
Bug 823628 - Followup to only show the revert column/buttons when the user is authorized to change tree state r=me

### DIFF
--- a/treestatus/templates/tree.html
+++ b/treestatus/templates/tree.html
@@ -157,7 +157,9 @@ window.onload = validateForm;
                 <table class="history">
                     <thead>
                         <tr>
+                        {% if 'REMOTE_USER' in request.environ: -%}
                           <th class="tableRevert"></th>
+                        {% endif -%}
                           <th class="tableWho">User</th>
                           <th class="tableWhen">Time</th>
                           <th class="tableState">Action</th>
@@ -168,11 +170,13 @@ window.onload = validateForm;
                     <tbody>
                         {% for log in logs: -%}
                         <tr>
+                        {% if 'REMOTE_USER' in request.environ: -%}
                             <td class="tableRevert">
                             {% if log.action != 'motd' -%}
                                 <input type="button" value="Revert to here" onclick="revertHere(this)"/>
                             {% endif -%}
                             </td>
+                        {% endif -%}
                             <td class="tableWho">
                             {% if 'REMOTE_USER' in request.environ: -%}
                                 {{log.who}}


### PR DESCRIPTION
The revert buttons were still being shown when I was signed out and the new state form wasn't shown. this hides the buttons in that case.